### PR TITLE
use constant hook

### DIFF
--- a/hardware-concurrency/index.js
+++ b/hardware-concurrency/index.js
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-import { useState } from 'react';
+import useConstant from 'use-constant';
 
 const useHardwareConcurrency = () => {
-  let initialHardwareConcurrency;
-  if ('hardwareConcurrency' in navigator) {
-    initialHardwareConcurrency = {numberOfLogicalProcessors: navigator.hardwareConcurrency};
-  } else {
-    initialHardwareConcurrency = {unsupported: true};
-  }
+  const hardwareConcurrency = useConstant(() => {
+    if ('hardwareConcurrency' in navigator) {
+      return {numberOfLogicalProcessors: navigator.hardwareConcurrency};
+    } else {
+      return {unsupported: true};
+    }
+  });
 
-  const [hardwareConcurrency] = useState(initialHardwareConcurrency);
-
-  return { ...hardwareConcurrency };
+  return hardwareConcurrency;
 };
 
 export { useHardwareConcurrency };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5722,6 +5722,11 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "use-constant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/use-constant/-/use-constant-1.0.0.tgz",
+      "integrity": "sha512-HmVrMl3+1tEr64ace4UtP5WTdnLyrvYKwF54JVf7B7lSB76JSERDvvgWkaaxlOM3S0dSl1U3WH1l9PupNnzsvQ=="
+    },
     "util.promisify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "hooks",
     "react",
     "performance"
-  ]
+  ],
+  "dependencies": {
+    "use-constant": "^1.0.0"
+  }
 }


### PR DESCRIPTION
`useConstant` is better way to use constants as a hook)

it's run ones, don't have invalidation and don't create logic for update value, it's size just [223B]( https://bundlephobia.com/result?p=use-constant@1.0.0)

I added `use-constant` as deps.
Do you think will be better move it to repo?