### PR TITLE
🔧 Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ branches:
   only:
     - master
 cache:
-  yarn: true
+  npm: true
   directories:
-    - node_module
+    - node_modules
 notifications:
   email: false
-install: yarn 
-script: yarn test
+install:
+  - npm ci
+script: npm run test


### PR DESCRIPTION
This PR updates Travis config to use `npm` instead of `yarn`.