### PR TITLE
Re-export hooks in index

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export { default as useNetworkStatus } from './network';
-export { default as useSaveData } from './save-data';
-export { default as useMemoryStatus } from './memory';
-export { default as useHardwareConcurrency } from './hardware-concurrency';
+export { useNetworkStatus } from './network';
+export { useSaveData } from './save-data';
+export { useMemoryStatus } from './memory';
+export { useHardwareConcurrency } from './hardware-concurrency';


### PR DESCRIPTION
The current hooks don't use `default` exports so the `/index.js` file was causing issues.