### PR TITLE
[core] add more guarding around global.navigator

### DIFF
--- a/hardware-concurrency/hardware-concurrency.test.js
+++ b/hardware-concurrency/hardware-concurrency.test.js
@@ -16,16 +16,22 @@
 
 import { renderHook } from '@testing-library/react-hooks';
 
+const tmp = Object.assign({}, global.navigator);
+
 afterEach(function() {
   // Reload hook for every test
   jest.resetModules();
+  // reset global.navigator mock to it's initial value after each test
+  global.navigator = Object.assign({}, tmp);
 });
 
 describe('useHardwareConcurrency', () => {
   test(`should return window.navigator.hardwareConcurrency`, () => {
     const { useHardwareConcurrency } = require('./');
     const { result } = renderHook(() => useHardwareConcurrency());
-    expect(result.current.numberOfLogicalProcessors).toBe(window.navigator.hardwareConcurrency);
+    expect(result.current.numberOfLogicalProcessors).toBe(
+      window.navigator.hardwareConcurrency
+    );
   });
 
   test('should return 4 for device of hardwareConcurrency = 4', () => {
@@ -50,5 +56,23 @@ describe('useHardwareConcurrency', () => {
     const { result } = renderHook(() => useHardwareConcurrency());
 
     expect(result.current.numberOfLogicalProcessors).toEqual(2);
+  });
+
+  test('should return `{unsupported: true}` if `navigator` is undefined', () => {
+    delete global.navigator;
+
+    const { useHardwareConcurrency } = require('./');
+    const { result } = renderHook(() => useHardwareConcurrency());
+
+    expect(result.current.unsupported).toEqual(true);
+  });
+
+  test('should return `{unsupported: true}` if `navigator.hardwareConcurrency` is not available', () => {
+    delete global.navigator.hardwareConcurrency;
+
+    const { useHardwareConcurrency } = require('./');
+    const { result } = renderHook(() => useHardwareConcurrency());
+
+    expect(result.current.unsupported).toEqual(true);
   });
 });

--- a/memory/index.js
+++ b/memory/index.js
@@ -25,9 +25,13 @@ if (!unsupported) {
   const performanceMemory = 'memory' in performance ? performance.memory : null;
   initialMemoryStatus = {
     deviceMemory: navigator.deviceMemory,
-    totalJSHeapSize: performanceMemory ? performanceMemory.totalJSHeapSize : null,
+    totalJSHeapSize: performanceMemory
+      ? performanceMemory.totalJSHeapSize
+      : null,
     usedJSHeapSize: performanceMemory ? performanceMemory.usedJSHeapSize : null,
-    jsHeapSizeLimit: performanceMemory ? performanceMemory.jsHeapSizeLimit : null
+    jsHeapSizeLimit: performanceMemory
+      ? performanceMemory.jsHeapSizeLimit
+      : null
   };
 } else {
   initialMemoryStatus = { unsupported };

--- a/memory/memory.test.js
+++ b/memory/memory.test.js
@@ -16,9 +16,13 @@
 
 import { renderHook } from '@testing-library/react-hooks';
 
+const tmp = Object.assign({}, global.navigator);
+
 afterEach(function() {
   // Reload hook for every test
   jest.resetModules();
+  // reset global.navigator mock to it's initial value after each test
+  global.navigator = Object.assign({}, tmp);
 });
 
 const getMemoryStatus = currentResult => ({
@@ -56,5 +60,32 @@ describe('useMemoryStatus', () => {
     const { result } = renderHook(() => useMemoryStatus());
 
     expect(getMemoryStatus(result.current)).toEqual(mockMemoryStatus);
+  });
+
+  test('should return `{unsupported: true}` if `navigator` is undefined', () => {
+    delete global.navigator;
+
+    const { useMemoryStatus } = require('./');
+    const { result } = renderHook(() => useMemoryStatus());
+
+    expect(result.current.unsupported).toEqual(true);
+  });
+
+  test('should return `{unsupported: true}` if `navigator.deviceMemory` is not available', () => {
+    delete global.navigator.deviceMemory;
+
+    const { useMemoryStatus } = require('./');
+    const { result } = renderHook(() => useMemoryStatus());
+
+    expect(result.current.unsupported).toEqual(true);
+  });
+
+  test('should return `{unsupported: true}` if `navigator.deviceMemory` is not available', () => {
+    delete global.navigator.deviceMemory;
+
+    const { useMemoryStatus } = require('./');
+    const { result } = renderHook(() => useMemoryStatus());
+
+    expect(result.current.unsupported).toEqual(true);
   });
 });

--- a/network/index.js
+++ b/network/index.js
@@ -19,17 +19,23 @@ import { useState, useEffect } from 'react';
 let unsupported;
 
 const useNetworkStatus = () => {
-  if ('connection' in navigator && 'effectiveType' in navigator.connection) {
+  if (
+    typeof navigator !== 'undefined' &&
+    'connection' in navigator &&
+    'effectiveType' in navigator.connection
+  ) {
     unsupported = false;
   } else {
     unsupported = true;
   }
 
-  const initialNetworkStatus = !unsupported ? {
-    effectiveConnectionType: navigator.connection.effectiveType
-  } : {
-      unsupported
-    };
+  const initialNetworkStatus = !unsupported
+    ? {
+        effectiveConnectionType: navigator.connection.effectiveType
+      }
+    : {
+        unsupported
+      };
 
   const [networkStatus, setNetworkStatus] = useState(initialNetworkStatus);
 
@@ -37,7 +43,9 @@ const useNetworkStatus = () => {
     if (!unsupported) {
       const navigatorConnection = navigator.connection;
       const updateECTStatus = () => {
-        setNetworkStatus({ effectiveConnectionType: navigatorConnection.effectiveType });
+        setNetworkStatus({
+          effectiveConnectionType: navigatorConnection.effectiveType
+        });
       };
       navigatorConnection.addEventListener('change', updateECTStatus);
       return () => {

--- a/network/network.test.js
+++ b/network/network.test.js
@@ -15,8 +15,14 @@
  */
 
 import { renderHook, act } from '@testing-library/react-hooks';
-
 import { useNetworkStatus } from './';
+
+const tmp = Object.assign({}, global.navigator);
+
+afterEach(function() {
+  // reset global.navigator mock to it's initial value after each test
+  global.navigator = Object.assign({}, tmp);
+});
 
 describe('useNetworkStatus', () => {
   test('should return 4g of effectiveConnectionType', () => {
@@ -27,15 +33,17 @@ describe('useNetworkStatus', () => {
     };
 
     const { result } = renderHook(() => useNetworkStatus());
-    
+
     expect(result.current.effectiveConnectionType).toEqual('4g');
   });
 
   test('should update the effectiveConnectionType state', () => {
     const { result } = renderHook(() => useNetworkStatus());
 
-    act(() => result.current.setNetworkStatus({effectiveConnectionType: '2g'}));
-  
+    act(() =>
+      result.current.setNetworkStatus({ effectiveConnectionType: '2g' })
+    );
+
     expect(result.current.effectiveConnectionType).toEqual('2g');
   });
 
@@ -54,5 +62,23 @@ describe('useNetworkStatus', () => {
     act(() => map.change());
 
     expect(result.current.effectiveConnectionType).toEqual('4g');
+  });
+
+  test('should return `{unsupported: true}` if `navigator` is undefined', () => {
+    delete global.navigator;
+    const { result } = renderHook(() => useNetworkStatus());
+    expect(result.current.unsupported).toEqual(true);
+  });
+
+  test('should return `{unsupported: true}` if `navigator.connection` is not available', () => {
+    delete global.navigator.connection;
+    const { result } = renderHook(() => useNetworkStatus());
+    expect(result.current.unsupported).toEqual(true);
+  });
+
+  test('should return `{unsupported: true}` if `navigator.connection.effectiveConnectionType` is not available', () => {
+    global.navigator.connection = {};
+    const { result } = renderHook(() => useNetworkStatus());
+    expect(result.current.unsupported).toEqual(true);
   });
 });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "jest": "^24.8.0",
     "react-test-renderer": "16.9.0"
   },
+  "prettier": {
+    "singleQuote": true
+  },
   "keywords": [
     "react-hooks",
     "hooks",

--- a/save-data/index.js
+++ b/save-data/index.js
@@ -15,7 +15,12 @@
  */
 
 let unsupported;
-if ('connection' in navigator && 'saveData' in navigator.connection) {
+
+if (
+  typeof navigator !== 'undefined' &&
+  'connection' in navigator &&
+  'saveData' in navigator.connection
+) {
   unsupported = false;
 } else {
   unsupported = true;

--- a/save-data/save-data.test.js
+++ b/save-data/save-data.test.js
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-import { renderHook, act } from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
+
+const tmp = Object.assign({}, global.navigator);
 
 afterEach(function() {
   // Reload hook for every test
   jest.resetModules();
+  // reset global.navigator mock to it's initial value after each test
+  global.navigator = Object.assign({}, tmp);
 });
 
 describe('useSaveData', () => {
@@ -46,5 +50,26 @@ describe('useSaveData', () => {
     const { result } = renderHook(() => useSaveData());
 
     expect(result.current.saveData).toEqual(navigator.connection.saveData);
+  });
+
+  test('should return `{unsupported: true}` if navigator is unavailable', () => {
+    delete global.navigator;
+    const { useSaveData } = require('./');
+    const { result } = renderHook(() => useSaveData());
+    expect(result.current.unsupported).toBe(true);
+  });
+
+  test('should return `{unsupported: true}` if navigator.connection is unavailable', () => {
+    delete global.navigator.connection;
+    const { useSaveData } = require('./');
+    const { result } = renderHook(() => useSaveData());
+    expect(result.current.unsupported).toBe(true);
+  });
+
+  test('should return `{unsupported: true}` if navigator.connection.saveData is unavailable', () => {
+    global.navigator.connection = {};
+    const { useSaveData } = require('./');
+    const { result } = renderHook(() => useSaveData());
+    expect(result.current.unsupported).toBe(true);
   });
 });


### PR DESCRIPTION
This PR will add more guarding around the global.navigator.

When I was experimenting with the `useNetworkStatus()` hook inside Gatsby I was getting build errors due to the fact it was trying to access `global.navigator` which is not available when trying to server-side-render with Gatsby.