### PR TITLE
Fix index re-exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-export { default as useNetworkStatus } from './network';
-export { default as useSaveData } from './save-data';
-export { default as useMemoryStatus } from './memory';
-export { default as useHardwareConcurrency } from './hardware-concurrency';
+export { useNetworkStatus } from './network';
+export { useSaveData } from './save-data';
+export { useMemoryStatus } from './memory';
+export { useHardwareConcurrency } from './hardware-concurrency';


### PR DESCRIPTION
@addyosmani Since #21 is in the chiller, I pulled this other fix out into a separate PR.

Currently, the individual hooks don't actually use the `default` export so the `/index.js` doesn't work when trying to re-export.