### PR TITLE
add mediaCapabilities hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,23 +160,51 @@ const { deviceMemory } = useMemoryStatus(initialMemoryStatus);
 
 ### Media Capabilities
 
-`useMediaCapabilities` utility for adapting based on the user's device media capabilities
+`useMediaCapabilities` utility for adapting based on the user's device media capabilities.
+
+**Use case:** useful for checking if we can play a certain media asset. For example, Safari does not support WebM so we want to fallback to mp4 but if Safari does support WebM it will automatically load WebM videos.
 
 ```js
 import React from 'react';
 
 import { useMediaCapabilities } from 'react-adaptive-hooks/media-capabilities';
 
-const MyComponent = ({ mediaConfig }) => {
-  const { mediaCapabilities } = useMediaCapabilities(mediaConfig);
+const webmMediaConfig = {
+  type : 'file', // 'record', 'transmission', or 'media-source'
+  video : {
+    contentType : 'video/webm;codecs=vp8', // valid content type
+    width : 800,     // width of the video
+    height : 600,    // height of the video
+    bitrate : 10000, // number of bits used to encode 1s of video
+    framerate : 30   // number of frames making up that 1s.
+  }
+};
+
+const initialDecodingInfo = { showWarning: true }
+
+const MyComponent = ({ videoSources }) => {
+  const { mediaCapabilities } = useMediaCapabilities(webmMediaConfig, initialDecodingInfo);
 
   return (
     <div>
-      { mediaCapabilities.supported ? <video muted controls>...</video> : <img src='...' /> }
+      {
+        mediaCapabilities.supported
+          ? <video src={videoSources.webm} controls>...</video>
+          : <video src={videoSources.mp4}  controls>...</video>
+      }
+      {
+        mediaCapabilities.showWarning &&
+          <div>
+            Defaulted to mp4.
+            Couldn't test webm support, either the media capabilities api is unavailable or no media configuration was given.
+          </div>
+      }
     </div>
   );
 };
 ```
+
+`useMediaCapabilities()` accepts a [media configuration](https://developer.mozilla.org/en-US/docs/Web/API/MediaConfiguration) object and an optional `initialMediaCapabilities` object to return when no media config is given or the Media Capabilities API is not available.
 
 ### Adaptive Code-loading & Code-splitting
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a suite of [React Hooks](https://reactjs.org/docs/hooks-overview.html) a
 * [Data Saver preferences](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/saveData)
 * [Device memory](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/deviceMemory)
 * [Logical CPU cores](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorConcurrentHardware/hardwareConcurrency)
+* [Media Capabilities API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Capabilities_API)
 
 It can be used to add patterns for adaptive resource loading, data-fetching, code-splitting and capability toggling.
 
@@ -28,6 +29,7 @@ import { useNetworkStatus } from 'react-adaptive-hooks/network';
 import { useSaveData } from 'react-adaptive-hooks/save-data';
 import { useHardwareConcurrency } from 'react-adaptive-hooks/hardware-concurrency';
 import { useMemoryStatus } from 'react-adaptive-hooks/memory';
+import { useMediaCapabilities } from 'react-adaptive-hooks/media-capabilities';
 
 ```
 
@@ -120,6 +122,26 @@ const MyComponent = () => {
   return (
     <div>
       { deviceMemory < 4 ? <img src='...' /> : <video muted controls>...</video> }
+    </div>
+  );
+};
+```
+
+### Media Capabilities
+
+`useMediaCapabilities` utility for adapting based on the user's device media capabilities
+
+```js
+import React from 'react';
+
+import { useMediaCapabilities } from 'react-adaptive-hooks/media-capabilities';
+
+const MyComponent = ({ mediaConfig }) => {
+  const { mediaCapabilities } = useMediaCapabilities(mediaConfig);
+
+  return (
+    <div>
+      { mediaCapabilities.supported ? <video muted controls>...</video> : <img src='...' /> }
     </div>
   );
 };
@@ -228,6 +250,8 @@ export default App;
 * [Performance memory API](https://developer.mozilla.org/en-US/docs/Web/API/Performance) is a non-standard and only available in [Chrome 7+, Opera, Chrome for Android 18+, Opera for Android](https://developer.mozilla.org/en-US/docs/Web/API/Performance/memory)
 
 * [Device Memory API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/deviceMemory) is available in [Chrome 63+, Opera 50+, Chrome for Android 76+, Opera for Android 46+](https://caniuse.com/#search=deviceMemory)
+
+* [Media Capabilities API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Capabilities_API) is available in [Chrome 63+, Firefox 63+, Opera 55+, Chrome for Android 78+, Firefox for Android 68+](https://caniuse.com/#search=media%20capabilities)
 
 ## Demos
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ const { deviceMemory } = useMemoryStatus(initialMemoryStatus);
 
 `useMediaCapabilities` utility for adapting based on the user's device media capabilities.
 
-**Use case:** useful for checking if we can play a certain media asset. For example, Safari does not support WebM so we want to fallback to mp4 but if Safari does support WebM it will automatically load WebM videos.
+**Use case:** this hook can be used to check if we can play a certain content type. For example, Safari does not support WebM so we want to fallback to MP4 but if Safari at some point does support WebM it will automatically load WebM videos.
 
 ```js
 import React from 'react';
@@ -194,7 +194,7 @@ const MyComponent = ({ videoSources }) => {
       }
       {
         mediaCapabilities.showWarning &&
-          <div>
+          <div class="muted">
             Defaulted to mp4.
             Couldn't test webm support, either the media capabilities api is unavailable or no media configuration was given.
           </div>
@@ -204,7 +204,7 @@ const MyComponent = ({ videoSources }) => {
 };
 ```
 
-`useMediaCapabilities()` accepts a [media configuration](https://developer.mozilla.org/en-US/docs/Web/API/MediaConfiguration) object and an optional `initialMediaCapabilities` object to return when no media config is given or the Media Capabilities API is not available.
+This hook accepts a [media configuration](https://developer.mozilla.org/en-US/docs/Web/API/MediaConfiguration) object argument and an optional `initialMediaCapabilities` object argument, which can be used to provide a `mediaCapabilities` state value when the user's browser does not support the relevant [Media Capabilities API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Capabilities_API) or no media configuration was given.
 
 ### Adaptive Code-loading & Code-splitting
 

--- a/index.js
+++ b/index.js
@@ -2,3 +2,4 @@ export { default as useNetworkStatus } from './network';
 export { default as useSaveData } from './save-data';
 export { default as useMemoryStatus } from './memory';
 export { default as useHardwareConcurrency } from './hardware-concurrency';
+export { default as useMediaCapabilities } from './media-capabilities';

--- a/media-capabilities/index.js
+++ b/media-capabilities/index.js
@@ -15,22 +15,12 @@
  */
 
 const useMediaCapabilities = (mediaConfig) => {
-    let mediaCapabilities = null
-
-    if (typeof window === 'undefined' || !('mediaCapabilities' in navigator)) {
-        mediaCapabilities = {
-            unsupported: true
-        }
+    let mediaCapabilities = {
+        supported: typeof window !== 'undefined' && 'mediaCapabilities' in navigator,
+        hasMediaConfig: !!mediaConfig
     }
 
-    if (!mediaConfig) {
-        mediaCapabilities = {
-            ...mediaCapabilities,
-            missingMediaConfig: true
-        }
-    }
-
-    if (!mediaCapabilities) {
+    if (mediaCapabilities.supported && mediaCapabilities.hasMediaConfig) {
         mediaCapabilities = navigator.mediaCapabilities.decodingInfo(mediaConfig)
     }
 

--- a/media-capabilities/index.js
+++ b/media-capabilities/index.js
@@ -16,26 +16,26 @@
 
 import { useState, useEffect } from 'react';
 
-const useMediaCapabilities = ({ mediaConfig } = {}) => {
-    const [mediaCapabilities, setMediaCapabilities] = useState(null);
+const useMediaCapabilities = (mediaConfig) => {
+    let initialMediaCapabilities = null
+
+    if (!('mediaCapabilities' in navigator)) {
+        initialMediaCapabilities = {
+            unsupported: true
+        }
+    }
+
+    if (!mediaConfig) {
+        initialMediaCapabilities = {
+            ...initialMediaCapabilities,
+            missingMediaConfig: true
+        }
+    }
+
+    const [mediaCapabilities, setMediaCapabilities] = useState(initialMediaCapabilities);
 
     useEffect(() => {
-        let validation = null
-
-        if (!('mediaCapabilities' in navigator)) {
-            validation = {
-                unsupported: true
-            }
-        }
-
-        if (!mediaConfig) {
-            validation = {
-                ...validation,
-                missingMediaConfig: true
-            }
-        }
-
-        setMediaCapabilities(validation || navigator.mediaCapabilities.decodingInfo(mediaConfig));
+        !initialMediaCapabilities && setMediaCapabilities(navigator.mediaCapabilities.decodingInfo(mediaConfig));
     }, []);
 
     return { mediaCapabilities };

--- a/media-capabilities/index.js
+++ b/media-capabilities/index.js
@@ -14,29 +14,25 @@
  * limitations under the License.
  */
 
-import { useState, useEffect } from 'react';
-
 const useMediaCapabilities = (mediaConfig) => {
-    let initialMediaCapabilities = null
+    let mediaCapabilities = null
 
-    if (!('mediaCapabilities' in navigator)) {
-        initialMediaCapabilities = {
+    if (typeof window === 'undefined' || !('mediaCapabilities' in navigator)) {
+        mediaCapabilities = {
             unsupported: true
         }
     }
 
     if (!mediaConfig) {
-        initialMediaCapabilities = {
-            ...initialMediaCapabilities,
+        mediaCapabilities = {
+            ...mediaCapabilities,
             missingMediaConfig: true
         }
     }
 
-    const [mediaCapabilities, setMediaCapabilities] = useState(initialMediaCapabilities);
-
-    useEffect(() => {
-        !initialMediaCapabilities && setMediaCapabilities(navigator.mediaCapabilities.decodingInfo(mediaConfig));
-    }, []);
+    if (!mediaCapabilities) {
+        mediaCapabilities = navigator.mediaCapabilities.decodingInfo(mediaConfig)
+    }
 
     return { mediaCapabilities };
 };

--- a/media-capabilities/index.js
+++ b/media-capabilities/index.js
@@ -14,17 +14,22 @@
  * limitations under the License.
  */
 
-const useMediaCapabilities = (mediaConfig) => {
+const useMediaCapabilities = (mediaConfig, initialMediaCapabilities = {}) => {
     let mediaCapabilities = {
         supported: typeof window !== 'undefined' && 'mediaCapabilities' in navigator,
         hasMediaConfig: !!mediaConfig
     }
 
-    if (mediaCapabilities.supported && mediaCapabilities.hasMediaConfig) {
-        mediaCapabilities = navigator.mediaCapabilities.decodingInfo(mediaConfig)
-    }
+    mediaCapabilities = (mediaCapabilities.supported && mediaCapabilities.hasMediaConfig) ?
+        navigator.mediaCapabilities.decodingInfo(mediaConfig) :
+        {
+            ...mediaCapabilities,
+            ...initialMediaCapabilities
+        }
 
     return { mediaCapabilities };
 };
 
-export { useMediaCapabilities };
+export {
+    useMediaCapabilities
+};

--- a/media-capabilities/index.js
+++ b/media-capabilities/index.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { useState, useEffect } from 'react';
+
+const useMediaCapabilities = ({ mediaConfig } = {}) => {
+    const [mediaCapabilities, setMediaCapabilities] = useState(null);
+
+    useEffect(() => {
+        let validation = null
+
+        if (!('mediaCapabilities' in navigator)) {
+            validation = {
+                unsupported: true
+            }
+        }
+
+        if (!mediaConfig) {
+            validation = {
+                ...validation,
+                missingMediaConfig: true
+            }
+        }
+
+        setMediaCapabilities(validation || navigator.mediaCapabilities.decodingInfo(mediaConfig));
+    }, []);
+
+    return { mediaCapabilities };
+};
+
+export { useMediaCapabilities };

--- a/media-capabilities/media-capabilities.test.js
+++ b/media-capabilities/media-capabilities.test.js
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the 'License');
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an 'AS IS' BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useMediaCapabilities } from './';
+
+const mediaCapabilitiesMapper = {
+    'audio/mp3': {
+        powerEfficient: true,
+        smooth: true,
+        supported: true
+    }
+}
+
+describe('useMediaCapabilities', () => {
+    test('should return message on unsupported platforms', () => {
+        const { result } = renderHook(() => useMediaCapabilities({ mediaConfig: true }));
+
+        expect(result.current.mediaCapabilities).toEqual({ unsupported: true });
+    });
+
+    test('should return message on unsupported platforms and no config is given', () => {
+        const { result } = renderHook(() => useMediaCapabilities());
+
+        expect(result.current.mediaCapabilities).toEqual({
+            missingMediaConfig: true,
+            unsupported: true
+        });
+    });
+
+    test('should return message when no config is given', () => {
+        Object.defineProperty(window.navigator, 'mediaCapabilities', {
+            value: true,
+            configurable: true,
+            writable: true
+        });
+
+        const { result } = renderHook(() => useMediaCapabilities());
+
+        expect(result.current.mediaCapabilities).toEqual({ 'missingMediaConfig': true });
+    });
+
+    test('should return MediaDecodingConfiguration for given media configuration', () => {
+        const mediaConfig = {
+            type: 'file',
+            audio: {
+                contentType: 'audio/mp3',
+                channels: 2,
+                bitrate: 132700,
+                samplerate: 5200
+            }
+        };
+
+        Object.defineProperty(window.navigator, 'mediaCapabilities', {
+            value: {
+                decodingInfo: (mediaConfig) => mediaCapabilitiesMapper[mediaConfig.audio.contentType]
+            },
+            configurable: true,
+            writable: true
+        });
+
+        const { result } = renderHook(() => useMediaCapabilities({ mediaConfig }));
+
+        expect(result.current.mediaCapabilities).toEqual({
+            powerEfficient: true,
+            smooth: true,
+            supported: true
+        });
+    });
+});

--- a/media-capabilities/media-capabilities.test.js
+++ b/media-capabilities/media-capabilities.test.js
@@ -37,22 +37,19 @@ const mediaCapabilitiesMapper = {
 }
 
 describe('useMediaCapabilities', () => {
-    test('should return unsupported flag on unsupported platforms', () => {
+    test('should return supported flag on supported platforms', () => {
         const { result } = renderHook(() => useMediaCapabilities(mediaConfig));
 
-        expect(result.current.mediaCapabilities).toEqual({ unsupported: true });
+        expect(result.current.mediaCapabilities).toEqual({ hasMediaConfig: true, supported: false });
     });
 
-    test('should return unsupported and missingMediaConfig flags on unsupported platforms and no config is given', () => {
+    test('should return supported and hasMediaConfig flags on supported platforms and no config is given', () => {
         const { result } = renderHook(() => useMediaCapabilities());
 
-        expect(result.current.mediaCapabilities).toEqual({
-            missingMediaConfig: true,
-            unsupported: true
-        });
+        expect(result.current.mediaCapabilities).toEqual({ hasMediaConfig: false, supported: false });
     });
 
-    test('should return missingMediaConfig when no config is given', () => {
+    test('should return hasMediaConfig flag when no config is given', () => {
         Object.defineProperty(window.navigator, 'mediaCapabilities', {
             value: true,
             configurable: true,
@@ -61,7 +58,7 @@ describe('useMediaCapabilities', () => {
 
         const { result } = renderHook(() => useMediaCapabilities());
 
-        expect(result.current.mediaCapabilities).toEqual({ missingMediaConfig: true });
+        expect(result.current.mediaCapabilities).toEqual({ hasMediaConfig: false, supported: true });
     });
 
     test('should return MediaDecodingConfiguration for given media configuration', () => {

--- a/media-capabilities/media-capabilities.test.js
+++ b/media-capabilities/media-capabilities.test.js
@@ -37,13 +37,13 @@ const mediaCapabilitiesMapper = {
 }
 
 describe('useMediaCapabilities', () => {
-    test('should return message on unsupported platforms', () => {
+    test('should return unsupported flag on unsupported platforms', () => {
         const { result } = renderHook(() => useMediaCapabilities(mediaConfig));
 
         expect(result.current.mediaCapabilities).toEqual({ unsupported: true });
     });
 
-    test('should return message on unsupported platforms and no config is given', () => {
+    test('should return unsupported and missingMediaConfig flags on unsupported platforms and no config is given', () => {
         const { result } = renderHook(() => useMediaCapabilities());
 
         expect(result.current.mediaCapabilities).toEqual({
@@ -52,7 +52,7 @@ describe('useMediaCapabilities', () => {
         });
     });
 
-    test('should return message when no config is given', () => {
+    test('should return missingMediaConfig when no config is given', () => {
         Object.defineProperty(window.navigator, 'mediaCapabilities', {
             value: true,
             configurable: true,
@@ -61,7 +61,7 @@ describe('useMediaCapabilities', () => {
 
         const { result } = renderHook(() => useMediaCapabilities());
 
-        expect(result.current.mediaCapabilities).toEqual({ 'missingMediaConfig': true });
+        expect(result.current.mediaCapabilities).toEqual({ missingMediaConfig: true });
     });
 
     test('should return MediaDecodingConfiguration for given media configuration', () => {

--- a/media-capabilities/media-capabilities.test.js
+++ b/media-capabilities/media-capabilities.test.js
@@ -37,30 +37,44 @@ const mediaCapabilitiesMapper = {
 }
 
 describe('useMediaCapabilities', () => {
-    test('should return supported flag on supported platforms', () => {
+    test('should return supported flag on unsupported platforms', () => {
         const { result } = renderHook(() => useMediaCapabilities(mediaConfig));
 
         expect(result.current.mediaCapabilities).toEqual({ hasMediaConfig: true, supported: false });
     });
 
-    test('should return supported and hasMediaConfig flags on supported platforms and no config is given', () => {
+    test('should return supported and hasMediaConfig flags on unsupported platforms and no config given', () => {
         const { result } = renderHook(() => useMediaCapabilities());
-
+        
         expect(result.current.mediaCapabilities).toEqual({ hasMediaConfig: false, supported: false });
     });
 
-    test('should return hasMediaConfig flag when no config is given', () => {
+    test('should return initialMediaCapabilities for unsupported', () => {
+        const initialMediaCapabilities = {
+            supported: true,
+            smooth: false,
+            powerEfficient: true
+        };
+
+        const { result } = renderHook(() => useMediaCapabilities(mediaConfig, initialMediaCapabilities));
+
+        expect(result.current.mediaCapabilities.supported).toBe(true);
+        expect(result.current.mediaCapabilities.smooth).toEqual(false);
+        expect(result.current.mediaCapabilities.powerEfficient).toEqual(true);
+    });
+
+    test('should return hasMediaConfig flag when no config given', () => {
         Object.defineProperty(window.navigator, 'mediaCapabilities', {
             value: true,
             configurable: true,
             writable: true
         });
-
+        
         const { result } = renderHook(() => useMediaCapabilities());
-
+        
         expect(result.current.mediaCapabilities).toEqual({ hasMediaConfig: false, supported: true });
     });
-
+    
     test('should return MediaDecodingConfiguration for given media configuration', () => {
         Object.defineProperty(window.navigator, 'mediaCapabilities', {
             value: {

--- a/media-capabilities/media-capabilities.test.js
+++ b/media-capabilities/media-capabilities.test.js
@@ -18,6 +18,16 @@ import { renderHook } from '@testing-library/react-hooks';
 
 import { useMediaCapabilities } from './';
 
+const mediaConfig = {
+    type: 'file',
+    audio: {
+        contentType: 'audio/mp3',
+        channels: 2,
+        bitrate: 132700,
+        samplerate: 5200
+    }
+};
+
 const mediaCapabilitiesMapper = {
     'audio/mp3': {
         powerEfficient: true,
@@ -28,7 +38,7 @@ const mediaCapabilitiesMapper = {
 
 describe('useMediaCapabilities', () => {
     test('should return message on unsupported platforms', () => {
-        const { result } = renderHook(() => useMediaCapabilities({ mediaConfig: true }));
+        const { result } = renderHook(() => useMediaCapabilities(mediaConfig));
 
         expect(result.current.mediaCapabilities).toEqual({ unsupported: true });
     });
@@ -55,16 +65,6 @@ describe('useMediaCapabilities', () => {
     });
 
     test('should return MediaDecodingConfiguration for given media configuration', () => {
-        const mediaConfig = {
-            type: 'file',
-            audio: {
-                contentType: 'audio/mp3',
-                channels: 2,
-                bitrate: 132700,
-                samplerate: 5200
-            }
-        };
-
         Object.defineProperty(window.navigator, 'mediaCapabilities', {
             value: {
                 decodingInfo: (mediaConfig) => mediaCapabilitiesMapper[mediaConfig.audio.contentType]
@@ -73,7 +73,7 @@ describe('useMediaCapabilities', () => {
             writable: true
         });
 
-        const { result } = renderHook(() => useMediaCapabilities({ mediaConfig }));
+        const { result } = renderHook(() => useMediaCapabilities(mediaConfig));
 
         expect(result.current.mediaCapabilities).toEqual({
             powerEfficient: true,


### PR DESCRIPTION
moved PR from GoogleChromeLabs/adaptive-loading/pull/60 

We use error flags in the other hooks, so I updated that for the mediaCapabilities hooks as well. Makes sense to use error flags indeed.

resolves #25 