### PR TITLE
[infra] Avoid using .mjs extension for module version of the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "private": false,
   "main": "dist/index.js",
-  "module": "dist/index.mjs",
+  "module": "dist/index.module.js",
   "unpkg": "dist/index.umd.js",
   "source": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR avoid using the extension `.mjs` for the module and fixes https://github.com/GoogleChromeLabs/react-adaptive-hooks/issues/40

It seems `create-react-app` doesn't have support to `.mjs`. As `webpack` 4 is using the `module` from the `package.json` this is breaking the bundle by not being able to load the library.

With this change `create-react-app` app usage is working again as expected.