### PR TITLE
[doc] notes for transpiled react-adaptive-hooks on server side rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,17 @@ const App = () => {
 export default App;
 ```
 
+## Notes
+
+The build version of this package is ESM by default but it's not supported on Server Side for now. So when we're using this package on universal app like Next.js app with server side rendering, we need to  
+
+* transpile the package by directly configuring babel or installing some plugin like [next-transpile-modules](https://github.com/martpie/next-transpile-modules). ([example project](https://github.com/GoogleChromeLabs/adaptive-loading/tree/master/next-show-adaptive-loading))
+
+* use UMD build like in the following code-snippet. ([example project](https://glitch.com/edit/#!/anton-karlovskiy-next-show-adaptive-loading?path=utils/hooks.js:19:91))
+```
+import { useNetworkStatus, useSaveData, useHardwareConcurrency, useMemoryStatus } from 'react-adaptive-hooks/dist/index.umd.js';
+```
+
 ## Browser Support
 
 * [Network Information API - effectiveType](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation/effectiveType) is available in [Chrome 61+, Opera 48+, Edge 76+, Chrome for Android 76+, Firefox for Android 68+](https://caniuse.com/#search=effectiveType)
@@ -292,7 +303,7 @@ export default App;
 ### Hybrid
 
 * [React Youtube - adaptive loading with mix of network, memory and hardware concurrency](https://github.com/GoogleChromeLabs/adaptive-loading/tree/master/react-youtube-adaptive-loading) ([Live](https://adaptive-loading.web.app/react-youtube-adaptive-loading/))
-
+* [Next Show - adaptive loading with mix of network, memory and Client Hints](https://github.com/GoogleChromeLabs/adaptive-loading/tree/master/next-show-adaptive-loading) ([demo](https://adaptive-loading.web.app/next-show-adaptive-loading/))
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -248,9 +248,9 @@ export default App;
 
 ## Server-side rendering support
 
-The built version of this package using ESM (ECMAScript Modules) by default, but is not supported on the server-side. When we are using this package in a universal meta-framework like Next.js with server-rendering, we need to:  
+The built version of this package uses ESM (native JS modules) by default, but is not supported on the server-side. When using this package in a web framework like Next.js with server-rendering, we recommend you
 
-* Transpile the package by directly configuring babel or installing [next-transpile-modules](https://github.com/martpie/next-transpile-modules). ([example project](https://github.com/GoogleChromeLabs/adaptive-loading/tree/master/next-show-adaptive-loading))
+* Transpile the package by installing [next-transpile-modules](https://github.com/martpie/next-transpile-modules). ([example project](https://github.com/GoogleChromeLabs/adaptive-loading/tree/master/next-show-adaptive-loading)). This is because Next.js currently does not pass `node_modules` into webpack server-side.
 
 * Use a UMD build as in the following code-snippet: ([example project](https://glitch.com/edit/#!/anton-karlovskiy-next-show-adaptive-loading?path=utils/hooks.js:19:91))
 ```

--- a/README.md
+++ b/README.md
@@ -246,13 +246,13 @@ const App = () => {
 export default App;
 ```
 
-## Notes
+## Server-side rendering support
 
-The build version of this package is ESM by default but it's not supported on Server Side for now. So when we're using this package on universal app like Next.js app with server side rendering, we need to  
+The built version of this package using ESM (ECMAScript Modules) by default, but is not supported on the server-side. When we are using this package in a universal meta-framework like Next.js with server-rendering, we need to:  
 
-* transpile the package by directly configuring babel or installing some plugin like [next-transpile-modules](https://github.com/martpie/next-transpile-modules). ([example project](https://github.com/GoogleChromeLabs/adaptive-loading/tree/master/next-show-adaptive-loading))
+* Transpile the package by directly configuring babel or installing [next-transpile-modules](https://github.com/martpie/next-transpile-modules). ([example project](https://github.com/GoogleChromeLabs/adaptive-loading/tree/master/next-show-adaptive-loading))
 
-* use UMD build like in the following code-snippet. ([example project](https://glitch.com/edit/#!/anton-karlovskiy-next-show-adaptive-loading?path=utils/hooks.js:19:91))
+* Use a UMD build as in the following code-snippet: ([example project](https://glitch.com/edit/#!/anton-karlovskiy-next-show-adaptive-loading?path=utils/hooks.js:19:91))
 ```
 import { useNetworkStatus, useSaveData, useHardwareConcurrency, useMemoryStatus } from 'react-adaptive-hooks/dist/index.umd.js';
 ```


### PR DESCRIPTION
@addyosmani 

The README is updated with `next-show-adaptive-loading` project.

> The next module transpilation issue is new to me. I can understand why it's needed, but was still a bit surprised by it.
I wonder if it's worth including a commit with a docs note for the Hooks README when we are making the change. I'm sure others will run into this problem.

I added some `Notes` for above issue in the README.