### PR TITLE
some suggestions to unify code

### DIFF
--- a/hardware-concurrency/index.js
+++ b/hardware-concurrency/index.js
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-let initialHardwareConcurrency;
-if (typeof navigator !== 'undefined' && 'hardwareConcurrency' in navigator) {
-  initialHardwareConcurrency = {
-    unsupported: false,
-    numberOfLogicalProcessors: navigator.hardwareConcurrency
+const useHardwareConcurrency = (initialHardwareConcurrency = null) => {
+  const supported = (typeof navigator !== 'undefined' && 'hardwareConcurrency' in navigator)
+
+  return {
+    unsupported: !supported,
+    numberOfLogicalProcessors: supported ?
+      navigator.hardwareConcurrency :
+      initialHardwareConcurrency
   };
-} else {
-  initialHardwareConcurrency = { unsupported: true };
-}
-const useHardwareConcurrency = () => {
-  return { ...initialHardwareConcurrency };
 };
 
 export { useHardwareConcurrency };

--- a/memory/index.js
+++ b/memory/index.js
@@ -14,34 +14,21 @@
  * limitations under the License.
  */
 
-let unsupported;
-if (typeof navigator !== 'undefined' && 'deviceMemory' in navigator) {
-  unsupported = false;
-} else {
-  unsupported = true;
-}
-let memoryStatus;
-if (!unsupported) {
-  const performanceMemory = 'memory' in performance ? performance.memory : null;
-  memoryStatus = {
-    unsupported,
-    deviceMemory: navigator.deviceMemory,
-    totalJSHeapSize: performanceMemory
-      ? performanceMemory.totalJSHeapSize
-      : null,
-    usedJSHeapSize: performanceMemory ? performanceMemory.usedJSHeapSize : null,
-    jsHeapSizeLimit: performanceMemory
-      ? performanceMemory.jsHeapSizeLimit
-      : null
-  };
-} else {
-  memoryStatus = { unsupported };
-}
+const useMemoryStatus = (initialMemoryStatus = null) => {
+  const supported = (typeof navigator !== 'undefined' && 'deviceMemory' in navigator)
+  const performanceMemory = (typeof performance !== 'undefined' && 'memory' in performance) ? performance.memory : {};
 
-const useMemoryStatus = initialMemoryStatus => {
-  return unsupported && initialMemoryStatus
-    ? { ...memoryStatus, ...initialMemoryStatus }
-    : { ...memoryStatus };
+  const memoryStatus = supported ? {
+    deviceMemory: navigator.deviceMemory,
+    totalJSHeapSize: performanceMemory.totalJSHeapSize || null,
+    usedJSHeapSize: performanceMemory.usedJSHeapSize || null,
+    jsHeapSizeLimit: performanceMemory.jsHeapSizeLimit || null
+  } : initialMemoryStatus;
+
+  return {
+    unsupported: !supported,
+    ...memoryStatus
+  }
 };
 
 export { useMemoryStatus };

--- a/network/index.js
+++ b/network/index.js
@@ -16,33 +16,29 @@
 
 import { useState, useEffect } from 'react';
 
-let unsupported;
-
-const useNetworkStatus = initialEffectiveConnectionType => {
-  if (typeof navigator !== 'undefined' && 'connection' in navigator && 'effectiveType' in navigator.connection) {
-    unsupported = false;
-  } else {
-    unsupported = true;
-  }
+const useNetworkStatus = (initialEffectiveConnectionType = null) => {
+  const supported = (typeof navigator !== 'undefined' && 'connection' in navigator && 'effectiveType' in navigator.connection)
 
   const initialNetworkStatus = {
-    unsupported,
-    effectiveConnectionType: unsupported
-      ? initialEffectiveConnectionType
-      : navigator.connection.effectiveType
+    unsupported: !supported,
+    effectiveConnectionType: supported
+      ? navigator.connection.effectiveType
+      : initialEffectiveConnectionType
   };
 
   const [networkStatus, setNetworkStatus] = useState(initialNetworkStatus);
 
   useEffect(() => {
-    if (!unsupported) {
+    if (supported) {
       const navigatorConnection = navigator.connection;
       const updateECTStatus = () => {
         setNetworkStatus({
           effectiveConnectionType: navigatorConnection.effectiveType
         });
       };
+
       navigatorConnection.addEventListener('change', updateECTStatus);
+
       return () => {
         navigatorConnection.removeEventListener('change', updateECTStatus);
       };

--- a/save-data/index.js
+++ b/save-data/index.js
@@ -14,20 +14,14 @@
  * limitations under the License.
  */
 
-let unsupported;
-
 const useSaveData = (initialSaveDataStatus = null) => {
-  if (typeof navigator !== 'undefined' && 'connection' in navigator && 'saveData' in navigator.connection) {
-    unsupported = false;
-  } else {
-    unsupported = true;
-  }
+  const supported = (typeof navigator !== 'undefined' && 'connection' in navigator && 'saveData' in navigator.connection)
 
   return {
-    unsupported,
-    saveData: unsupported
-      ? initialSaveDataStatus
-      : navigator.connection.saveData === true
+    unsupported: !supported,
+    saveData: supported ?
+      navigator.connection.saveData === true :
+      initialSaveDataStatus
   };
 };
 


### PR DESCRIPTION
kicking off #37

wondering if we could change the api response to return a `supported` property instead of the existing `unsupported` property. If we change it to `supported` there is no double negatives confusion.