### PR TITLE
Pick up updates triggered between render & useEffect

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,5 +17,10 @@
 module.exports = {
   presets: [
     "@babel/preset-env"
-  ]
+  ],
+  env: {
+    test: {
+      presets: [["@babel/preset-env", { targets: { node: "current" }}]]
+    }
+  }
 };

--- a/network/network.test.js
+++ b/network/network.test.js
@@ -144,11 +144,9 @@ describe('useNetworkStatus', () => {
       return effectiveConnectionType;
     }
     const container = document.createElement('div');
-    TestUtils.act(() => {
-      render(createElement(App), container);
-    });
+    render(createElement(App), container);
 
-    console.log(container.innerHTML);
+    expect(container.innerHTML).toBe('2g');
     
     // update
     TestUtils.act(() => {
@@ -156,10 +154,7 @@ describe('useNetworkStatus', () => {
       ectStatusListeners.dispatchEvent(new Event('change'));
     });
 
-    console.log(container.innerHTML);
-    // await waitForNextUpdate();
-    // await act(async () => {});
-    // rerender();
-    // expect(result.current.effectiveConnectionType).toBe('4g');
+    expect(container.innerHTML).toBe('4g');
+    unmountComponentAtNode(container);
   })
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -7548,6 +7548,18 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-dom": {
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.15.0"
+      }
+    },
     "react-is": {
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "jest": "^24.8.0",
     "microbundle": "0.11.0",
     "react": "16.9.0",
+    "react-dom": "16.9.0",
     "react-test-renderer": "16.9.0"
   },
   "keywords": [


### PR DESCRIPTION
useEffect isn't called synchronously after render. There's a slight chance a change event is dispatched after our initial read but _before_ we register our listener in useEffect.

Timeline:
```
useState(initialValue) --- "change" event triggered --- useEffect (subscribe)
```